### PR TITLE
Fix android 4.X compatibility

### DIFF
--- a/WhatAndroid/src/main/java/what/whatandroid/barcode/BarcodeAdapter.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/barcode/BarcodeAdapter.java
@@ -48,8 +48,10 @@ public class BarcodeAdapter extends ArrayAdapter<Barcode> {
 			holder.barcodeSecondary = (TextView)convertView.findViewById(R.id.barcode_secondary);
 			holder.dateScanned = (TextView)convertView.findViewById(R.id.date_scanned);
 			holder.loadTerms = (ImageButton)convertView.findViewById(R.id.load_terms);
+			holder.loadTerms.setImageResource(R.drawable.ic_file_download_24dp);
 			holder.loadingSpinner = (ProgressBar)convertView.findViewById(R.id.loading_indicator);
 			holder.delete = (ImageButton)convertView.findViewById(R.id.delete);
+			holder.delete.setImageResource(R.drawable.ic_search_24dp);
 			holder.searchTorrents = (Button)convertView.findViewById(R.id.search_torrents);
 			holder.searchRequests = (Button)convertView.findViewById(R.id.search_requests);
 			holder.loadTermsListener = new LoadTermsListener(holder);

--- a/WhatAndroid/src/main/java/what/whatandroid/bookmarks/ArtistBookmarkAdapter.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/bookmarks/ArtistBookmarkAdapter.java
@@ -43,6 +43,7 @@ public class ArtistBookmarkAdapter extends ArrayAdapter<Artist> implements Adapt
 			holder = new ViewHolder();
 			holder.title = (TextView)convertView.findViewById(R.id.title);
 			holder.removeBookmark = (ImageButton)convertView.findViewById(R.id.remove_bookmark);
+			holder.removeBookmark.setImageResource(R.drawable.ic_bookmark_24dp);
 			//Hide unused views
 			View year = convertView.findViewById(R.id.year);
 			View tags = convertView.findViewById(R.id.tags);

--- a/WhatAndroid/src/main/java/what/whatandroid/comments/CommentsAdapter.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/comments/CommentsAdapter.java
@@ -7,14 +7,7 @@ import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.ImageButton;
-import android.widget.ImageView;
-import android.widget.ProgressBar;
-import android.widget.TextView;
-
-import java.util.Date;
-
+import android.widget.*;
 import api.comments.SimpleComment;
 import what.whatandroid.R;
 import what.whatandroid.WhatApplication;
@@ -23,6 +16,8 @@ import what.whatandroid.callbacks.ViewUserCallbacks;
 import what.whatandroid.imgloader.HtmlImageHider;
 import what.whatandroid.imgloader.ImageLoadFailTracker;
 import what.whatandroid.settings.SettingsActivity;
+
+import java.util.Date;
 
 /**
  * Adapter for displaying a list of user comments
@@ -91,9 +86,11 @@ public class CommentsAdapter extends ArrayAdapter<SimpleComment> implements View
 			holder.commentText = (TextView)convertView.findViewById(R.id.comment_text);
 			holder.artContainer = convertView.findViewById(R.id.art_container);
 			holder.image = (ImageView)convertView.findViewById(R.id.image);
+			holder.image.setImageResource(R.drawable.ic_reply_24dp);
 			holder.spinner = (ProgressBar)convertView.findViewById(R.id.loading_indicator);
 			holder.userClickListener = new UserClickListener();
 			holder.quote = (ImageButton) convertView.findViewById(R.id.reply_quote);
+
 			View header = convertView.findViewById(R.id.user_header);
 			header.setOnClickListener(holder.userClickListener);
 			convertView.setTag(holder);

--- a/WhatAndroid/src/main/java/what/whatandroid/forums/forum/ForumListAdapterDefault.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/forums/forum/ForumListAdapterDefault.java
@@ -5,16 +5,14 @@ import android.support.v4.content.ContextCompat;
 import android.text.format.DateUtils;
 import android.view.View;
 import android.view.ViewGroup;
-
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import java.util.Date;
-
 import api.forum.forum.ForumThread;
 import api.soup.MySoup;
 import what.whatandroid.R;
+
+import java.util.Date;
 
 /**
  * Adapter for showing a listing of forum threads, default version
@@ -40,8 +38,12 @@ public class ForumListAdapterDefault extends ForumListAdapter {
 			holder.lastPostAuthor = (TextView)convertView.findViewById(R.id.last_post_username);
 			holder.lastPostTime = (TextView)convertView.findViewById(R.id.last_post_time);
 			holder.jumpToLastRead = (ImageButton)convertView.findViewById(R.id.go_to_last_read);
+			holder.jumpToLastRead.setImageResource(R.drawable.ic_forward_24dp);
 			holder.sticky = (ImageView) convertView.findViewById(R.id.sticky_thread);
+			holder.sticky.setImageResource(R.drawable.ic_star_24dp);
 			holder.locked = (ImageView) convertView.findViewById(R.id.locked_thread);
+			holder.locked.setImageResource(R.drawable.ic_lock_24dp);
+
 			convertView.setTag(holder);
 		}
 

--- a/WhatAndroid/src/main/java/what/whatandroid/forums/forum/ForumListAdapterLight.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/forums/forum/ForumListAdapterLight.java
@@ -33,8 +33,11 @@ public class ForumListAdapterLight extends ForumListAdapter {
             holder = new ViewHolder();
             holder.name = (TextView)convertView.findViewById(R.id.thread_name);
             holder.jumpToLastRead = (ImageButton)convertView.findViewById(R.id.go_to_last_read);
+            holder.jumpToLastRead.setImageResource(R.drawable.ic_forward_24dp);
             holder.sticky = (ImageView) convertView.findViewById(R.id.sticky_thread);
+            holder.jumpToLastRead.setImageResource(R.drawable.ic_star_24dp);
             holder.locked = (ImageView) convertView.findViewById(R.id.locked_thread);
+            holder.jumpToLastRead.setImageResource(R.drawable.ic_lock_24dp);
             convertView.setTag(holder);
         }
 

--- a/WhatAndroid/src/main/java/what/whatandroid/inbox/InboxListAdapter.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/inbox/InboxListAdapter.java
@@ -10,12 +10,11 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import java.util.Date;
-
 import api.inbox.inbox.Message;
 import what.whatandroid.R;
 import what.whatandroid.callbacks.ViewConversationCallbacks;
+
+import java.util.Date;
 
 /**
  * Adapter for displaying a list of conversations in the inbox
@@ -48,6 +47,7 @@ public class InboxListAdapter extends ArrayAdapter<Message> implements AdapterVi
 			holder.sender = (TextView)convertView.findViewById(R.id.sender);
 			holder.date = (TextView)convertView.findViewById(R.id.date);
 			holder.sticky = (ImageView)convertView.findViewById(R.id.sticky_thread);
+			holder.sticky.setImageResource(R.drawable.ic_star_24dp);
 			convertView.setTag(holder);
 		}
 		Message message = getItem(position);

--- a/WhatAndroid/src/main/java/what/whatandroid/settings/FolderPickerDialog.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/settings/FolderPickerDialog.java
@@ -8,21 +8,14 @@ import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.EditText;
-import android.widget.ImageButton;
-import android.widget.ListView;
-import android.widget.TextView;
-import android.widget.Toast;
+import android.widget.*;
+import what.whatandroid.R;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import what.whatandroid.R;
 
 /**
  * A dialog fragment for navigating to and selecting a folder
@@ -96,10 +89,11 @@ public class FolderPickerDialog extends DialogFragment
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 		LayoutInflater inflater = getActivity().getLayoutInflater();
 		View view = inflater.inflate(R.layout.dialog_folder_picker, null);
-		((ImageButton)view.findViewById(R.id.new_folder)).setImageResource(R.drawable.ic_add_24dp);
 		currentDirTitle = (TextView)view.findViewById(R.id.current_folder);
 		ListView list = (ListView)view.findViewById(R.id.list);
-		view.findViewById(R.id.new_folder).setOnClickListener(this);
+		ImageButton imgAddFolder = (ImageButton) view.findViewById(R.id.new_folder);
+		imgAddFolder.setImageResource(R.drawable.ic_add_24dp);
+		imgAddFolder.setOnClickListener(this);
 
 		if (savedInstanceState != null){
 			currentDir = new File(savedInstanceState.getString(DIRECTORY));

--- a/WhatAndroid/src/main/java/what/whatandroid/subscriptions/SubscriptionsAdapter.java
+++ b/WhatAndroid/src/main/java/what/whatandroid/subscriptions/SubscriptionsAdapter.java
@@ -5,22 +5,17 @@ import android.os.AsyncTask;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.BaseAdapter;
-import android.widget.ImageButton;
-import android.widget.TextView;
-import android.widget.Toast;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
+import android.widget.*;
 import api.subscriptions.ForumThread;
 import api.subscriptions.Subscriptions;
 import api.util.Tuple;
 import what.whatandroid.R;
 import what.whatandroid.callbacks.ViewForumCallbacks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Adapter for displaying the list of subscriptions,
@@ -114,6 +109,7 @@ public class SubscriptionsAdapter extends BaseAdapter implements AdapterView.OnI
 			holder = new ItemViewHolder();
 			holder.name = (TextView) convertView.findViewById(R.id.title);
 			holder.unsubscribe = (ImageButton) convertView.findViewById(R.id.unsubscribe);
+			holder.unsubscribe.setImageResource(R.drawable.ic_visibility_24dp);
 			convertView.setTag(holder);
 		}
 		ForumThread thread = (ForumThread) getItem(position);

--- a/WhatAndroid/src/main/res/layout/fragment_recent_torrent.xml
+++ b/WhatAndroid/src/main/res/layout/fragment_recent_torrent.xml
@@ -7,7 +7,7 @@
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
         android:paddingBottom="4dp"
-        android:background="@color/BackgroundAccent"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">
     <RelativeLayout

--- a/WhatAndroid/src/main/res/layout/list_barcode.xml
+++ b/WhatAndroid/src/main/res/layout/list_barcode.xml
@@ -34,7 +34,6 @@
             android:layout_alignParentTop="true"
             android:layout_alignParentRight="true"
             android:layout_marginBottom="8dp"
-            android:src="@drawable/ic_delete_24dp"
             android:contentDescription="@string/delete"
             style="?android:attr/borderlessButtonStyle"/>
 
@@ -44,7 +43,6 @@
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_search_24dp"
             android:contentDescription="@string/load_terms"
             style="?android:attr/borderlessButtonStyle"/>
 

--- a/WhatAndroid/src/main/res/layout/list_forum.xml
+++ b/WhatAndroid/src/main/res/layout/list_forum.xml
@@ -5,6 +5,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">
     <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/WhatAndroid/src/main/res/layout/list_forum_category.xml
+++ b/WhatAndroid/src/main/res/layout/list_forum_category.xml
@@ -5,6 +5,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">
     <LinearLayout

--- a/WhatAndroid/src/main/res/layout/list_forum_thread.xml
+++ b/WhatAndroid/src/main/res/layout/list_forum_thread.xml
@@ -103,7 +103,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:src="@drawable/ic_star_24dp"
                     android:contentDescription="@string/sticky_thread"
                     android:tint="@color/accent"
                     android:visibility="gone"/>
@@ -113,7 +112,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:src="@drawable/ic_lock_24dp"
                     android:contentDescription="@string/locked_thread"
                     android:tint="@color/accent"
                     android:visibility="gone"/>
@@ -123,7 +121,6 @@
                     android:layout_width="60dp"
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/go_to_last_read"
-                    android:src="@drawable/ic_forward_24dp"
                     android:tint="@color/accent"
                     style="?android:attr/borderlessButtonStyle"/>
 

--- a/WhatAndroid/src/main/res/layout/list_forum_thread.xml
+++ b/WhatAndroid/src/main/res/layout/list_forum_thread.xml
@@ -2,10 +2,11 @@
 
 <android.support.v7.widget.CardView
         xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        xmlns:card_view="http://schemas.android.com/apk/res-auto" xmlns:app="http://schemas.android.com/tools"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">
     <RelativeLayout

--- a/WhatAndroid/src/main/res/layout/list_forum_thread_light.xml
+++ b/WhatAndroid/src/main/res/layout/list_forum_thread_light.xml
@@ -50,7 +50,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:src="@drawable/ic_star_24dp"
                     android:contentDescription="@string/sticky_thread"
                     android:tint="@color/LightGrey"
                     android:visibility="gone"/>
@@ -60,7 +59,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:src="@drawable/ic_lock_24dp"
                     android:contentDescription="@string/locked_thread"
                     android:tint="@color/LightGrey"
                     android:visibility="gone"/>
@@ -70,7 +68,6 @@
                     android:layout_width="32dp"
                     android:layout_height="26dp"
                     android:contentDescription="@string/go_to_last_read"
-                    android:src="@drawable/ic_forward_24dp"
                     style="?android:attr/borderlessButtonStyle"
                     android:layout_marginTop="2dp"/>
 

--- a/WhatAndroid/src/main/res/layout/list_forum_thread_light.xml
+++ b/WhatAndroid/src/main/res/layout/list_forum_thread_light.xml
@@ -7,6 +7,7 @@
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
         android:paddingBottom="4dp"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">
     <RelativeLayout

--- a/WhatAndroid/src/main/res/layout/list_group.xml
+++ b/WhatAndroid/src/main/res/layout/list_group.xml
@@ -5,6 +5,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_group_torrent.xml
+++ b/WhatAndroid/src/main/res/layout/list_group_torrent.xml
@@ -6,6 +6,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_message.xml
+++ b/WhatAndroid/src/main/res/layout/list_message.xml
@@ -6,6 +6,7 @@
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
         android:paddingBottom="4dp"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">
     <LinearLayout

--- a/WhatAndroid/src/main/res/layout/list_message.xml
+++ b/WhatAndroid/src/main/res/layout/list_message.xml
@@ -37,7 +37,6 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentRight="true"
-                    android:src="@drawable/ic_star_24dp"
                     android:contentDescription="@string/sticky_thread"
                     android:tint="@color/LightGrey"
                     android:visibility="gone"/>

--- a/WhatAndroid/src/main/res/layout/list_poll_answer.xml
+++ b/WhatAndroid/src/main/res/layout/list_poll_answer.xml
@@ -4,6 +4,7 @@
         xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:id="@+id/card_root_view"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"

--- a/WhatAndroid/src/main/res/layout/list_request.xml
+++ b/WhatAndroid/src/main/res/layout/list_request.xml
@@ -5,6 +5,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_request_search.xml
+++ b/WhatAndroid/src/main/res/layout/list_request_search.xml
@@ -4,6 +4,7 @@
         xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:id="@+id/card_root_view"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"

--- a/WhatAndroid/src/main/res/layout/list_similar_artist.xml
+++ b/WhatAndroid/src/main/res/layout/list_similar_artist.xml
@@ -2,6 +2,7 @@
 <android.support.v7.widget.CardView
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:card_view="http://schemas.android.com/apk/res-auto"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"

--- a/WhatAndroid/src/main/res/layout/list_subscription.xml
+++ b/WhatAndroid/src/main/res/layout/list_subscription.xml
@@ -33,7 +33,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:paddingLeft="8dp"
-                android:src="@drawable/ic_visibility_24dp"
                 android:contentDescription="@string/unsubscribe"
                 android:layout_alignParentRight="true"
                 style="?android:attr/borderlessButtonStyle"/>

--- a/WhatAndroid/src/main/res/layout/list_subscription.xml
+++ b/WhatAndroid/src/main/res/layout/list_subscription.xml
@@ -2,7 +2,7 @@
 <android.support.v7.widget.CardView
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:card_view="http://schemas.android.com/apk/res-auto"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"

--- a/WhatAndroid/src/main/res/layout/list_top_torrent.xml
+++ b/WhatAndroid/src/main/res/layout/list_top_torrent.xml
@@ -6,6 +6,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_torrent_bookmark.xml
+++ b/WhatAndroid/src/main/res/layout/list_torrent_bookmark.xml
@@ -4,6 +4,7 @@
         xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:id="@+id/card_root_view"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"

--- a/WhatAndroid/src/main/res/layout/list_torrent_bookmark.xml
+++ b/WhatAndroid/src/main/res/layout/list_torrent_bookmark.xml
@@ -24,7 +24,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
-                android:src="@drawable/ic_bookmark_24dp"
                 android:contentDescription="@string/remove_bookmark"
                 style="?android:attr/borderlessButtonStyle"/>
 

--- a/WhatAndroid/src/main/res/layout/list_torrent_file.xml
+++ b/WhatAndroid/src/main/res/layout/list_torrent_file.xml
@@ -5,6 +5,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_torrent_notification.xml
+++ b/WhatAndroid/src/main/res/layout/list_torrent_notification.xml
@@ -6,6 +6,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_torrent_search.xml
+++ b/WhatAndroid/src/main/res/layout/list_torrent_search.xml
@@ -5,6 +5,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_user_comment.xml
+++ b/WhatAndroid/src/main/res/layout/list_user_comment.xml
@@ -52,7 +52,6 @@
                     android:layout_width="32dp"
                     android:layout_height="32dp"
                     android:layout_alignParentRight="true"
-                    android:src="@drawable/ic_reply_24dp"
                     style="?android:attr/borderlessButtonStyle"
                     android:contentDescription="@string/reply"
                     android:visibility="gone"/>

--- a/WhatAndroid/src/main/res/layout/list_user_comment.xml
+++ b/WhatAndroid/src/main/res/layout/list_user_comment.xml
@@ -5,6 +5,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">

--- a/WhatAndroid/src/main/res/layout/list_user_search.xml
+++ b/WhatAndroid/src/main/res/layout/list_user_search.xml
@@ -6,6 +6,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/card_root_view"
+        card_view:cardBackgroundColor="@color/BackgroundAccent"
         android:paddingBottom="4dp"
         card_view:cardCornerRadius="4dp"
         card_view:cardUseCompatPadding="true">


### PR DESCRIPTION
Fixed cardviews on dark theme
Prevent xml inflation errors on 4.X by moving all (I think I got them all anyway...) image views and image button src= tags to be assigned in java code instead.